### PR TITLE
Add git submodule example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "templates-git-submodule"]
+	path = templates-git-submodule
+	url = https://github.com/env0/templates-git-submodule

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "templates-git-submodule"]
-	path = templates-git-submodule
+[submodule "misc/git-modules/child"]
+	path = misc/git-modules/child
 	url = https://github.com/env0/templates-git-submodule

--- a/misc/git-modules/.gitmodules
+++ b/misc/git-modules/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "child"]
+	path = child
+	url = ssh://git@github.com/env0/templates-private/templates-git-submodule/child.git

--- a/misc/git-modules/.gitmodules
+++ b/misc/git-modules/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "child"]
-	path = child
-	url = ssh://git@github.com/env0/templates-private/templates-git-submodule/child.git

--- a/misc/git-modules/README.md
+++ b/misc/git-modules/README.md
@@ -1,0 +1,3 @@
+# Git Modules
+This is an example of using [Git Modules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) defined via `.gitmodules` (unlike terraform module).  
+


### PR DESCRIPTION
# Git Modules
This is an example of using [Git Modules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) defined via `.gitmodules` (unlike terraform module).  

