### PR TITLE
Adding template to validate state on redeploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Thumbnails
 ._*
+
+.terraform
+*.tfstate
+*.tfstate.backup

--- a/misc/validate-state/env0.yml
+++ b/misc/validate-state/env0.yml
@@ -1,0 +1,7 @@
+version: 1
+
+deploy:
+  steps:
+    terraformPlan:
+      after:
+        - ./validate.sh

--- a/misc/validate-state/main.tf
+++ b/misc/validate-state/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "0.12.24"
+}
+
+resource "null_resource" "null1" {
+}
+
+resource "null_resource" "null2" {
+}

--- a/misc/validate-state/validate.sh
+++ b/misc/validate-state/validate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+if [[ "$IS_REDEPLOY" == "true" ]];
+then
+  EXPECTED_PLAN_OUTPUT="Plan: 0 to add, 0 to change, 0 to destroy."
+  PLAN_OUTPUT=$(terraform show -no-color .tf-plan | tail -1)
+  if [[ "$PLAN_OUTPUT" == "$EXPECTED_PLAN_OUTPUT" ]];
+  then
+    echo "Redeploy plan is OK"
+    exit 0
+  else
+    echo "Validation Failed, Redeploy plan is $PLAN_OUTPUT";
+    exit 1
+  fi
+else
+  echo "Not Redeploy so not validating"
+fi


### PR DESCRIPTION
### Feature Request
We have some issues where state isn't preserved between runs, causing the environment to re-deploy from zero.

### Solution
The added template will be used to verify that on re-deploy, the actual plan is with 0 changes.
It will be used in the nightly deployment test suite.

