### PR TITLE
Fix: chnaged gcp tf version to be 0.12.31

### DIFF
--- a/gcp/bq-dataset/main.tf
+++ b/gcp/bq-dataset/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version  = "=0.12.3"
+  required_version  = "=0.12.31"
 }
 
 resource "random_id" "id" {


### PR DESCRIPTION
We need to update the latest TF version of 0.12.x version as Hashi had a security issue with their GPG signing keys.

https://www.bleepingcomputer.com/news/security/hashicorp-is-the-latest-victim-of-codecov-supply-chain-attack/