### PR TITLE
added sensitive = true

### DIFF
--- a/aws/ec2-redash/outputs.tf
+++ b/aws/ec2-redash/outputs.tf
@@ -1,6 +1,7 @@
 output "tls_private_key" {
   value = tls_private_key.private_key.private_key_pem
   description = "The private key to be used in order to ssh to the ec2 instance"
+  sensitive = true
 }
 
 output "instance_public_ip" {

--- a/aws/ec2-redash/outputs.tf
+++ b/aws/ec2-redash/outputs.tf
@@ -8,3 +8,4 @@ output "instance_public_ip" {
   value = aws_eip.redash-elastic-ip.public_ip
   description = "The public IP of your Redash instance"
 }
+


### PR DESCRIPTION
in terraform v 15 we get this error
```
> /opt/tfenv/bin/terraform plan -out=.tf-plan
╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 1:
│    1: output "tls_private_key" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
```
in the terraform plan stage