### PR TITLE
fix(opa): update binary to opa_linux_amd64_static

### DIFF
--- a/aws/opa-example/env0.yml
+++ b/aws/opa-example/env0.yml
@@ -3,7 +3,7 @@ deploy:
   steps:
     setupVariables:
       after:
-        - curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
+        - curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
         - chmod 755 ./opa
         - ./opa version
     terraformPlan:


### PR DESCRIPTION
prevent an error related to a missing library
"ld-linux-x86-64.so.2: No such file or directory (needed by ./opa)"