### PR TITLE
Chore update tf version for gcp

### DIFF
--- a/gcp/bq-dataset/main.tf
+++ b/gcp/bq-dataset/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version  = "=0.12.31"
+  required_version  = "=0.14.11"
 }
 
 resource "random_id" "id" {


### PR DESCRIPTION
Looks like version 4.20.0 of google is broken with tf version 0.12.31
so upgrade that

https://github.com/hashicorp/terraform-provider-google/issues/10671