### PR TITLE
Fix: S3 terraform v0.11.x example

### DIFF
--- a/aws/s3-bucket/tf-11/main.tf
+++ b/aws/s3-bucket/tf-11/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.11.15"
+  required_version = "~> 0.11.15"
 }
 
 module "s3" {

--- a/aws/s3-bucket/tf-11/main.tf
+++ b/aws/s3-bucket/tf-11/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.11.14"
+  required_version = "0.11.15"
 }
 
 module "s3" {

--- a/aws/s3-bucket/tf-12/main.tf
+++ b/aws/s3-bucket/tf-12/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.12.29"
+  required_version = "~> 0.12.29"
 }
 
 module "s3" {

--- a/aws/s3-bucket/tf-13/main.tf
+++ b/aws/s3-bucket/tf-13/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.3"
+  required_version = "~>0.13.3"
 }
 
 module "s3" {

--- a/aws/s3-bucket/tf-13/main.tf
+++ b/aws/s3-bucket/tf-13/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~>0.13.3"
+  required_version = "~> 0.13.3"
 }
 
 module "s3" {


### PR DESCRIPTION
terraform v0.11.14 didn't [work](https://dev.dev.env0.com/p/48cebe74-cbc1-4f7a-80e4-c5ae9f1d98fa/environments/5cf1e7f5-fab9-486d-aa74-bd9e2bb5c8d8) with the latest aws provider version because:

> HashiCorp has rotated its release signing key as a part of HCSEC-2021-12
https://stackoverflow.com/questions/67368339/error-installing-provider-aws-openpgp-signature-made-by-unknown-entity

Solution:
Change the version constraint to always take the latest patch version to prevent future cases.

