### PR TITLE
Fix: check for venv for python3

### DIFF
--- a/misc/ensure-permissions-on-tools-and-folders-for-user-node/ensure-permissions.sh
+++ b/misc/ensure-permissions-on-tools-and-folders-for-user-node/ensure-permissions.sh
@@ -31,4 +31,5 @@ touch /tmp/test
 rm /tmp/test
 touch /home/node/test
 rm /home/node/test
+python3 -m venv -h
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Need to make sure venv  is installed in the deployment service container

### Solution
add it to `ensure-permissions.sh`