### PR TITLE
Vault Server & Client Templates

### DIFF
--- a/aws/vault-server-on-eks/README.md
+++ b/aws/vault-server-on-eks/README.md
@@ -1,0 +1,5 @@
+### Vault Server on EKS template
+
+- Creates a very basically configured Vault server to run on our EKS cluster
+- Used to test integration with Vault
+- This server is not meant for any actual production/secret use - it's configured as lightly as possible.

--- a/aws/vault-server-on-eks/README.md
+++ b/aws/vault-server-on-eks/README.md
@@ -1,5 +1,21 @@
-### Vault Server on EKS template
+# Vault Server on EKS template
 
 - Creates a very basically configured Vault server to run on our EKS cluster
 - Used to test integration with Vault
 - This server is not meant for any actual production/secret use - it's configured as lightly as possible.
+
+## Expected variables
+
+- AWS credentials
+- `TF_VAR_cluster_name` - the cluster name to install the Vault server in
+- `TF_VAR_dev_root_token` - the root token (password) that will be needed to login to Vault
+- `CLAIM_ORG_ID` - The org ID we will allow OIDC login with (to Vault)
+- `VAULT_ROLE` - The Vault role name (that will be created)
+- `CLAIM_AUDIENCES` - The audiences to allow OIDC login for
+- `VAULT_NAMESPACE` - The Vault namespace to use
+
+## Outputs
+
+- This Vault instance is expected to be used in our integration tests, which run `misc/vault-integration`
+- That script needs `VAULT_ROLE` & `VAULT_NAMESPACE` that were defined here
+- And also `VAULT_ADDR` which the script here outputs in the end

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -31,7 +31,7 @@ path "secrets-for-env0/*" {
 EOF
 
 ./vault auth enable -path=env0-jwt/ jwt
-./vault write auth/env0-jwt/config jwks_url="https://login.app.env0.com/.well-known/jwks.json"
+./vault write auth/env0-jwt/config jwks_url="https://login.dev.env0.com/.well-known/jwks.json"
 
 ./vault write auth/env0-jwt/role/$ROLE_NAME - <<EOF
 {

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -16,8 +16,11 @@ echo "VAULT_HOST is $VAULT_HOST"
 export VAULT_ADDR=http://$VAULT_HOST:8200
 export VAULT_TOKEN=$TF_VAR_dev_root_token
 
+# Cleaning up anything previously configured
+./vault secrets disable secrets-for-env0/ || true
+./vault auth disable env0-jwt/ || true
+
 # Configuring vault
-./vault secrets disable secrets-for-env0/ 
 ./vault secrets enable -path=secrets-for-env0/ kv
 
 # # Bound a ACL policy for permissions

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -18,24 +18,24 @@ export VAULT_TOKEN=$TF_VAR_dev_root_token
 
 # Configuring vault
 # # Create KV store type
-vault secrets enable -path=secrets-for-env0/ kv
+./vault secrets enable -path=secrets-for-env0/ kv
 
 # # Bound a ACL policy for permissions
-vault policy write env0-access - <<EOF
+./vault policy write env0-access - <<EOF
 path "secrets-for-env0/*" {
     capabilities = ["read", "create", "update"]
 }
 EOF
 
-vault auth enable -path=env0-jwt/ jwt
-vault write auth/env0-jwt/config jwks_url="https://login.app.env0.com/.well-known/jwks.json"
+./vault auth enable -path=env0-jwt/ jwt
+./vault write auth/env0-jwt/config jwks_url="https://login.app.env0.com/.well-known/jwks.json"
 
 # # Create auth for our bors integration tests org 
 
 export BORS_TEST_ORG_ID="214afc56-607b-447a-a533-5f3f6d608539"
 export ROLE_NAME=bors-env0-integration-tests-role
 
-vault write auth/env0-jwt/role/$ROLE_NAME - <<EOF
+./vault write auth/env0-jwt/role/$ROLE_NAME - <<EOF
 {
   "user_claim": "sub",
   "role_type": "jwt",

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -33,7 +33,7 @@ EOF
 ./vault auth enable -path=env0-jwt/ jwt
 ./vault write auth/env0-jwt/config jwks_url="https://login.dev.env0.com/.well-known/jwks.json"
 
-./vault write auth/env0-jwt/role/$ROLE_NAME - <<EOF
+./vault write auth/env0-jwt/role/$VAULT_ROLE - <<EOF
 {
   "user_claim": "sub",
   "role_type": "jwt",

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -7,7 +7,13 @@ curl -sL https://releases.hashicorp.com/vault/1.11.1/vault_1.11.1_linux_amd64.zi
 unzip -o vault1.zip
 ./vault --version
 
-export VAULT_ADDR=http://$(kubectl get service self-hosted-vault-ui -n self-hosted-vault -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'):8200
+aws eks --region=us-east-1 update-kubeconfig --name TF_VAR_cluster_name
+
+VAULT_HOST=$(kubectl get service self-hosted-vault-ui -n self-hosted-vault -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+
+echo "VAULT_HOST is $VAULT_HOST"
+
+export VAULT_ADDR=http://$VAULT_HOST:8200
 export VAULT_TOKEN=$TF_VAR_dev_root_token
 
 # Configuring vault

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -30,25 +30,19 @@ EOF
 ./vault auth enable -path=env0-jwt/ jwt
 ./vault write auth/env0-jwt/config jwks_url="https://login.app.env0.com/.well-known/jwks.json"
 
-# # Create auth for our bors integration tests org 
-
-export BORS_TEST_ORG_ID="214afc56-607b-447a-a533-5f3f6d608539"
-export ROLE_NAME=bors-env0-integration-tests-role
-
 ./vault write auth/env0-jwt/role/$ROLE_NAME - <<EOF
 {
   "user_claim": "sub",
   "role_type": "jwt",
   "bound_audiences": [
-    "https://dev.env0.com",
-    "https://dev-env0.auth0.com/userinfo"
+    $CLAIM_AUDIENCES    
   ],
   "bound_claims": {
-    "https://env0.com/organization": "$BORS_TEST_ORG_ID",
+    "https://env0.com/organization": "$CLAIM_ORG_ID",
     "https://env0.com/apiKeyType": "oidc"
   },
   "policies": ["env0-access"]
 }
 EOF
-‍
+
 echo $VAULT_ADDR

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# INSTALLING VAULT
+echo "1. Installing vault..."
+curl -sL https://releases.hashicorp.com/vault/1.11.1/vault_1.11.1_linux_amd64.zip -o vault1.zip
+unzip -o vault1.zip
+./vault --version

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -17,7 +17,7 @@ export VAULT_ADDR=http://$VAULT_HOST:8200
 export VAULT_TOKEN=$TF_VAR_dev_root_token
 
 # Configuring vault
-# # Create KV store type
+./vault secrets disable -path=secrets-for-env0/ kv
 ./vault secrets enable -path=secrets-for-env0/ kv
 
 # # Bound a ACL policy for permissions

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -7,7 +7,7 @@ curl -sL https://releases.hashicorp.com/vault/1.11.1/vault_1.11.1_linux_amd64.zi
 unzip -o vault1.zip
 ./vault --version
 
-aws eks --region=us-east-1 update-kubeconfig --name TF_VAR_cluster_name
+aws eks --region=us-east-1 update-kubeconfig --name $TF_VAR_cluster_name
 
 VAULT_HOST=$(kubectl get service self-hosted-vault-ui -n self-hosted-vault -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -6,3 +6,43 @@ echo "1. Installing vault..."
 curl -sL https://releases.hashicorp.com/vault/1.11.1/vault_1.11.1_linux_amd64.zip -o vault1.zip
 unzip -o vault1.zip
 ./vault --version
+
+export VAULT_ADDR=http://$(kubectl get service self-hosted-vault-ui -n self-hosted-vault -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'):8200
+export VAULT_TOKEN=$TF_VAR_dev_root_token
+
+# Configuring vault
+# # Create KV store type
+vault secrets enable -path=secrets-for-env0/ kv
+
+# # Bound a ACL policy for permissions
+vault policy write env0-access - <<EOF
+path "secrets-for-env0/*" {
+    capabilities = ["read", "create", "update"]
+}
+EOF
+
+vault auth enable -path=env0-jwt/ jwt
+vault write auth/env0-jwt/config jwks_url="https://login.app.env0.com/.well-known/jwks.json"
+
+# # Create auth for our bors integration tests org 
+
+export BORS_TEST_ORG_ID="214afc56-607b-447a-a533-5f3f6d608539"
+export ROLE_NAME=bors-env0-integration-tests-role
+
+vault write auth/env0-jwt/role/$ROLE_NAME - <<EOF
+{
+  "user_claim": "sub",
+  "role_type": "jwt",
+  "bound_audiences": [
+    "https://dev.env0.com",
+    "https://dev-env0.auth0.com/userinfo"
+  ],
+  "bound_claims": {
+    "https://env0.com/organization": "$BORS_TEST_ORG_ID",
+    "https://env0.com/apiKeyType": "oidc"
+  },
+  "policies": ["env0-access"]
+}
+EOF
+‍
+echo $VAULT_ADDR

--- a/aws/vault-server-on-eks/configure-vault.sh
+++ b/aws/vault-server-on-eks/configure-vault.sh
@@ -17,7 +17,7 @@ export VAULT_ADDR=http://$VAULT_HOST:8200
 export VAULT_TOKEN=$TF_VAR_dev_root_token
 
 # Configuring vault
-./vault secrets disable -path=secrets-for-env0/ kv
+./vault secrets disable secrets-for-env0/ 
 ./vault secrets enable -path=secrets-for-env0/ kv
 
 # # Bound a ACL policy for permissions

--- a/aws/vault-server-on-eks/env0.yml
+++ b/aws/vault-server-on-eks/env0.yml
@@ -1,0 +1,5 @@
+version: 1
+
+deploy:
+  onCompletion:
+    - ./configure-vault.sh

--- a/aws/vault-server-on-eks/main.tf
+++ b/aws/vault-server-on-eks/main.tf
@@ -1,0 +1,22 @@
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1alpha1"
+      args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+      command     = "aws"
+    }
+  }
+}
+
+resource "helm_release" "example" {
+  name             = "test-hello-world"
+  namespace        = "test-hello-world"
+  chart            = "https://cloudecho.github.io/charts/hello-0.1.2.tgz"
+  create_namespace = true
+}

--- a/aws/vault-server-on-eks/main.tf
+++ b/aws/vault-server-on-eks/main.tf
@@ -26,4 +26,9 @@ resource "helm_release" "vault_release" {
   values = [
     "${file("vault-config.yaml")}"
   ]
+
+  set {
+    name  = "server.dev.devRootToken"
+    value = var.dev_root_token
+  }
 }

--- a/aws/vault-server-on-eks/main.tf
+++ b/aws/vault-server-on-eks/main.tf
@@ -14,9 +14,10 @@ provider "helm" {
   }
 }
 
-resource "helm_release" "example" {
-  name             = "test-hello-world"
-  namespace        = "test-hello-world"
-  chart            = "https://cloudecho.github.io/charts/hello-0.1.2.tgz"
+resource "helm_release" "vault_release" {
+  name             = "self-hosted-vault"
+  namespace        = "self-hosted-vault"
+  repository       = "https://helm.releases.hashicorp.com"
+  chart            = "hashicorp/vault"
   create_namespace = true
 }

--- a/aws/vault-server-on-eks/main.tf
+++ b/aws/vault-server-on-eks/main.tf
@@ -18,6 +18,6 @@ resource "helm_release" "vault_release" {
   name             = "self-hosted-vault"
   namespace        = "self-hosted-vault"
   repository       = "https://helm.releases.hashicorp.com"
-  chart            = "hashicorp/vault"
+  chart            = "vault"
   create_namespace = true
 }

--- a/aws/vault-server-on-eks/main.tf
+++ b/aws/vault-server-on-eks/main.tf
@@ -20,4 +20,10 @@ resource "helm_release" "vault_release" {
   repository       = "https://helm.releases.hashicorp.com"
   chart            = "vault"
   create_namespace = true
+
+  // Configuration reference in
+  // https://www.vaultproject.io/docs/platform/k8s/helm/configuration
+  values = [
+    "${file("vault-config.yaml")}"
+  ]
 }

--- a/aws/vault-server-on-eks/providers.tf
+++ b/aws/vault-server-on-eks/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "= 2.5.1"
+    }
+  }
+}

--- a/aws/vault-server-on-eks/variables.tf
+++ b/aws/vault-server-on-eks/variables.tf
@@ -1,0 +1,1 @@
+variable "cluster_name" {}

--- a/aws/vault-server-on-eks/variables.tf
+++ b/aws/vault-server-on-eks/variables.tf
@@ -1,1 +1,5 @@
 variable "cluster_name" {}
+variable "dev_root_token" {
+  description = "Will be used as the root token for the vault server"
+  sensitive   = true
+}

--- a/aws/vault-server-on-eks/vault-config.yaml
+++ b/aws/vault-server-on-eks/vault-config.yaml
@@ -1,0 +1,10 @@
+server:
+  dev:
+    enabled: true
+  ingress:
+    enabled: true
+injector:
+  enabled: false
+ui:
+  enabled: true
+  serviceType: LoadBalancer

--- a/misc/vault-integration/README.md
+++ b/misc/vault-integration/README.md
@@ -1,0 +1,5 @@
+### Vault Integration test template
+
+- This template runs a Hashicorp Vault _client_ that's meant to test the JWT integration with a running Vault server instance.
+- It runs the `vault.sh` script. which in turn authenticates against vault. It consists of two parts - creating a role, if a $VAULT_TOKEN exists, and actually using the JWT token to login to this role.
+- `VAULT_ROLE`, `VAULT_NAMESPACE`, `VAULT_ADDR` - these should be supplied as env vars to the deployment

--- a/misc/vault-integration/README.md
+++ b/misc/vault-integration/README.md
@@ -2,4 +2,4 @@
 
 - This template runs a Hashicorp Vault _client_ that's meant to test the JWT integration with a running Vault server instance.
 - It runs the `vault.sh` script which authenticates against vault.
-- `VAULT_ROLE`, `VAULT_NAMESPACE`, `VAULT_ADDR` - these should be supplied as env vars to the deployment
+- `VAULT_ROLE`, `VAULT_NAMESPACE`, `VAULT_ADDR` - these should be supplied as env vars to the deployment. See `aws/vault-server-on-eks/README.md` for more info.

--- a/misc/vault-integration/README.md
+++ b/misc/vault-integration/README.md
@@ -1,5 +1,5 @@
 ### Vault Integration test template
 
 - This template runs a Hashicorp Vault _client_ that's meant to test the JWT integration with a running Vault server instance.
-- It runs the `vault.sh` script. which in turn authenticates against vault. It consists of two parts - creating a role, if a $VAULT_TOKEN exists, and actually using the JWT token to login to this role.
+- It runs the `vault.sh` script which authenticates against vault.
 - `VAULT_ROLE`, `VAULT_NAMESPACE`, `VAULT_ADDR` - these should be supplied as env vars to the deployment

--- a/misc/vault-integration/env0.yml
+++ b/misc/vault-integration/env0.yml
@@ -4,4 +4,4 @@ deploy:
   steps:
     setupVariables:
       after:
-        - chmod +x ./vault.sh && ./vault.sh
+        - ./vault.sh

--- a/misc/vault-integration/vault.sh
+++ b/misc/vault-integration/vault.sh
@@ -1,24 +1,20 @@
 #!/bin/bash
+set -e
 
 if [[ -z "$VAULT_ADDR" || -z "$VAULT_NAMESPACE" || -z "$VAULT_ROLE" ]]; then
     echo "MISSING REQUIRED VARIABLES: VAULT_ROLE, VAULT_NAMESPACE, VAULT_ADDR"
     exit 1
 fi
 
-# INSTALLING VAULT
-echo "1. Installing vault..."
+echo "Installing vault..."
+
 curl -sL https://releases.hashicorp.com/vault/1.11.1/vault_1.11.1_linux_amd64.zip -o vault1.zip
 unzip -o vault1.zip
 ./vault --version
 
-echo "================="
+echo "Running some vault commands"
 
-echo "2. Logging in using JWT"
-#USAGE
-if ! ./vault write auth/env0-jwt/login role="${VAULT_ROLE}" jwt="${ENV0_OIDC_TOKEN}" ;# IF IT WORKS - YOU SHOULD SUCCESSFULLY SEE THE KEYS
-then
-  exit 1
-fi
-
-echo "================="
-echo "Done."
+./vault write auth/env0-jwt/login role="${VAULT_ROLE}" jwt="${ENV0_OIDC_TOKEN}"
+./vault kv put -mount=secrets-for-env0 creds passcode=my-long-passcode
+./vault kv get -mount=secrets-for-env0 -field=passcode creds
+        

--- a/misc/vault-integration/vault.sh
+++ b/misc/vault-integration/vault.sh
@@ -12,9 +12,12 @@ curl -sL https://releases.hashicorp.com/vault/1.11.1/vault_1.11.1_linux_amd64.zi
 unzip -o vault1.zip
 ./vault --version
 
+echo "Logging in to Vault"
+
+export VAULT_TOKEN=$(./vault write auth/env0-jwt/login role="${VAULT_ROLE}" jwt="${ENV0_OIDC_TOKEN}" -format=json | jq --raw-output '.auth.client_token')
+
 echo "Running some vault commands"
 
-./vault write auth/env0-jwt/login role="${VAULT_ROLE}" jwt="${ENV0_OIDC_TOKEN}"
 ./vault kv put -mount=secrets-for-env0 creds passcode=my-long-passcode
 ./vault kv get -mount=secrets-for-env0 -field=passcode creds
         

--- a/misc/vault-integration/vault.sh
+++ b/misc/vault-integration/vault.sh
@@ -4,45 +4,14 @@ if [[ -z "$VAULT_ADDR" || -z "$VAULT_NAMESPACE" || -z "$VAULT_ROLE" ]]; then
     echo "MISSING REQUIRED VARIABLES: VAULT_ROLE, VAULT_NAMESPACE, VAULT_ADDR"
     exit 1
 fi
+
 # INSTALLING VAULT
 echo "1. Installing vault..."
 curl -sL https://releases.hashicorp.com/vault/1.11.1/vault_1.11.1_linux_amd64.zip -o vault1.zip
 unzip -o vault1.zip
 ./vault --version
+
 echo "================="
-if [[ ! -z "$VAULT_TOKEN" ]]; then
-    echo '1.1 Found VAULT_TOKEN, creating JWT role... '
-    # CREATION
-    # VAULT_TOKEN IS REQUIRED FOR CREATION
-    echo "VAULT_ADDR: ${VAULT_ADDR}"
-    echo "VAULT_NAMESPACE: ${VAULT_NAMESPACE}"
-    echo "VAULT_ROLE: ${VAULT_ROLE}"
-
-    if [[ $STAGE == "prod" ]]; then
-      ENV0_BOUND_AUDIENCE="https://prod.env0.com"
-      AUTH0_BOUND_AUDIENCE="https://env0.auth0.com/userinfo"
-    else
-      ENV0_BOUND_AUDIENCE="https://dev.env0.com"
-      AUTH0_BOUND_AUDIENCE="https://dev-env0.auth0.com/userinfo"
-    fi
-
-  ./vault write auth/jwt/role/"${VAULT_ROLE}" - <<EOF
-{
-  "user_claim": "sub",
-  "role_type": "jwt",
-  "bound_audiences": [
-    "$ENV0_BOUND_AUDIENCE",
-    "$AUTH0_BOUND_AUDIENCE"
-  ],
-  "bound_claims": {
-    "https://env0.com/organization": "$ENV0_ORGANIZATION_ID",
-    "https://env0.com/apiKeyType": "oidc"
-  }
-}
-EOF
-echo "================="
-fi
-
 
 echo "2. Logging in using JWT"
 #USAGE

--- a/misc/vault-integration/vault.sh
+++ b/misc/vault-integration/vault.sh
@@ -15,7 +15,7 @@ echo "================="
 
 echo "2. Logging in using JWT"
 #USAGE
-if ! ./vault write auth/jwt/login role="${VAULT_ROLE}" jwt="${ENV0_OIDC_TOKEN}" ;# IF IT WORKS - YOU SHOULD SUCCESSFULLY SEE THE KEYS
+if ! ./vault write auth/env0-jwt/login role="${VAULT_ROLE}" jwt="${ENV0_OIDC_TOKEN}" ;# IF IT WORKS - YOU SHOULD SUCCESSFULLY SEE THE KEYS
 then
   exit 1
 fi


### PR DESCRIPTION
# Issue
Since we ran out of Vault SaaS, we need a vault instance to run our integration tests in.

# Solution
- Add a template for running a Vault instance on our K8S cluster
- Touchup the 'client' test script for clarity and order. 
- Ran both templates - server in https://dev.dev.env0.com/p/b2a2cb34-0d23-4909-92e5-7db172015e12/environments/71d8a482-5a10-4da4-90c6-297716f334cc and client in the bors integration tests org. 