### PR TITLE
Validating "magic" var

### DIFF
--- a/misc/custom-flows-environment-variables/env0.yml
+++ b/misc/custom-flows-environment-variables/env0.yml
@@ -7,6 +7,7 @@ deploy:
         - echo USER_NAME=user >> $ENV0_ENV
         - echo FULL_NAME_WITH_WHITESPACE=\"John Doe\" >> $ENV0_ENV
         - ./export-user-id.sh
+        - echo "Populating ENV0_TERRAFORM_CONFIG_FILE_PATH - will be tested in main.tf to find an actual variable"
         - echo ENV0_TERRAFORM_CONFIG_FILE_PATH=var-file.json >> $ENV0_ENV
       after:
         - echo $USER_NAME
@@ -18,3 +19,4 @@ deploy:
         - '[ "$FULL_NAME_WITH_WHITESPACE" == "John Doe" ]'
         - "[ $USER_ID == user_id ]"
         - "[ $IN_SAME_STEP == works ]"
+        - "[ $ENV0_TERRAFORM_CONFIG_FILE_PATH == var-file.json ]"

--- a/misc/custom-flows-environment-variables/env0.yml
+++ b/misc/custom-flows-environment-variables/env0.yml
@@ -7,11 +7,14 @@ deploy:
         - echo USER_NAME=user >> $ENV0_ENV
         - echo FULL_NAME_WITH_WHITESPACE=\"John Doe\" >> $ENV0_ENV
         - ./export-user-id.sh
+        - echo ENV0_TERRAFORM_CONFIG_FILE_PATH=var-file.json >> $ENV0_ENV
       after:
         - echo $USER_NAME
         - echo $FULL_NAME_WITH_WHITESPACE
         - ./print-user-id.sh
-        - echo "Asserting expected values..."
+        - echo IN_SAME_STEP=works >> $ENV0_ENV
+        - echo "****** Asserting expected values..."
         - "[ $USER_NAME == user ]"
-        - "[ \"$FULL_NAME_WITH_WHITESPACE\" == \"John Doe\" ]"
+        - '[ "$FULL_NAME_WITH_WHITESPACE" == "John Doe" ]'
         - "[ $USER_ID == user_id ]"
+        - "[ $IN_SAME_STEP == works ]"

--- a/misc/custom-flows-environment-variables/main.tf
+++ b/misc/custom-flows-environment-variables/main.tf
@@ -1,2 +1,6 @@
+variable "my-mandatory-var" {
+  description = "This is mandatory and we will set it up using a magic var instantiated from a custom flow"
+}
+
 resource "null_resource" "null" {
 }

--- a/misc/custom-flows-environment-variables/var-file.json
+++ b/misc/custom-flows-environment-variables/var-file.json
@@ -1,0 +1,3 @@
+{
+  "my-mandatory-var": "this is the value of the Mandalorian var"
+}


### PR DESCRIPTION
Adding some lines to the `custom-flows-environment-variables` flow to also validate we are getting "magic" vars that are dynamically added.

Will only work after https://github.com/env0/env0/pull/10439