### PR TITLE
Fix: Custom flow env vars - Set var-file on destroy as well

### DIFF
--- a/misc/custom-flows-environment-variables/env0.yml
+++ b/misc/custom-flows-environment-variables/env0.yml
@@ -20,3 +20,8 @@ deploy:
         - "[ $USER_ID == user_id ]"
         - "[ $IN_SAME_STEP == works ]"
         - "[ $ENV0_TERRAFORM_CONFIG_FILE_PATH == var-file.json ]"
+destroy:
+  steps:
+    terraformPlan:
+      before:
+        - echo ENV0_TERRAFORM_CONFIG_FILE_PATH=var-file.json >> $ENV0_ENV


### PR DESCRIPTION
This template is used in our automated integration tests, but it fails to destroy, because I forgot to specify the vars-file on the destroy spec.