### PR TITLE
FIX: incorrect template names in workflow template

### DIFF
--- a/misc/workflow-environment-basic/env0.workflow.yml
+++ b/misc/workflow-environment-basic/env0.workflow.yml
@@ -1,7 +1,10 @@
 environments:
   rootService1:
     name: nullService1
-    templateName: 'null resource'
+    templateName: 'null-resource'
+    workspace: 'null-service-1'
   rootService2:
     name: nullService2
-    templateName: 'null resource'
+    templateName: 'null-resource'
+    workspace: 'null-service-2'
+

--- a/misc/workflow-environment-basic/env0.workflow.yml
+++ b/misc/workflow-environment-basic/env0.workflow.yml
@@ -1,10 +1,10 @@
 environments:
   rootService1:
     name: nullService1
-    templateName: 'null-resource'
+    templateName: 'workflow-subenv-null-resource'
     workspace: 'null-service-1'
   rootService2:
     name: nullService2
-    templateName: 'null-resource'
+    templateName: 'workflow-subenv-null-resource'
     workspace: 'null-service-2'
 


### PR DESCRIPTION
- added a workspace name configuration because it would fail if both environments had the same workspace name on the same template
- changes the template names to be more explicit