### PR TITLE
Fix: s3 bucket template misconfiguration 

### DIFF
--- a/aws/s3-bucket/s3/s3.tf
+++ b/aws/s3-bucket/s3/s3.tf
@@ -44,7 +44,10 @@ resource "aws_s3_bucket_acl" "bucket_acl" {
 
 resource "aws_s3_bucket_policy" "bucket_policy" {
   bucket = aws_s3_bucket.website_bucket.id
-  depends_on = [aws_s3_bucket_public_access_block.bucket_public_access_block]
+  depends_on = [
+    aws_s3_bucket_ownership_controls.bucket_ownership,
+    aws_s3_bucket_public_access_block.bucket_public_access_block
+  ]
 
   policy = <<POLICY
 {


### PR DESCRIPTION
Continuing #169, there was a missing dependency between `aws_s3_bucket_ownership_controls.bucket_ownership` and the policy created in the same file