### PR TITLE
Chore: remove unused s3 bucket examples ACL

### DIFF
--- a/aws/hello-world/output.tf
+++ b/aws/hello-world/output.tf
@@ -1,3 +1,3 @@
 output "url" {
-  value = aws_s3_bucket.website_bucket.website_endpoint
+  value = aws_s3_bucket_website_configuration.website_config.website_endpoint
 }

--- a/aws/hello-world/s3.tf
+++ b/aws/hello-world/s3.tf
@@ -39,16 +39,6 @@ resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
   restrict_public_buckets = false
 }
 
-resource "aws_s3_bucket_acl" "bucket_acl" {
-  depends_on = [
-    aws_s3_bucket_ownership_controls.bucket_ownership,
-    aws_s3_bucket_public_access_block.bucket_public_access_block
-  ]
-
-  bucket = aws_s3_bucket.website_bucket.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_policy" "website_bucket_policy" {
   bucket = aws_s3_bucket.website_bucket.id
   depends_on = [
@@ -78,4 +68,3 @@ resource "aws_s3_object" "object" {
   source = "index.html"
   content_type = "text/html"
 }
-

--- a/aws/s3-bucket/s3/s3.tf
+++ b/aws/s3-bucket/s3/s3.tf
@@ -32,16 +32,6 @@ resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
   restrict_public_buckets = false
 }
 
-resource "aws_s3_bucket_acl" "bucket_acl" {
-  depends_on = [
-    aws_s3_bucket_ownership_controls.bucket_ownership,
-    aws_s3_bucket_public_access_block.bucket_public_access_block,
-  ]
-
-  bucket = aws_s3_bucket.website_bucket.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_policy" "bucket_policy" {
   bucket = aws_s3_bucket.website_bucket.id
   depends_on = [


### PR DESCRIPTION
there's an `aws_s3_bucket_acl` configured for the s3 bucket templates that might cause an issue when deploying alongside a public bucket policy