### PR TITLE
Chore: Add explicit workspace name

### DIFF
--- a/misc/workflow-environment-basic/env0.workflow.yml
+++ b/misc/workflow-environment-basic/env0.workflow.yml
@@ -2,6 +2,8 @@ environments:
   rootService1:
     name: nullService1
     templateName: 'null resource'
+    workspace: rootService1
   rootService2:
     name: nullService2
     templateName: 'null resource'
+    workspace: rootService2


### PR DESCRIPTION
After the change in this [pr](https://github.com/env0/env0/pull/11769) we now don't allow having more than one environment of the same template with the same workspace name. In our provider integration tests we do not give a workspace name so all the sub environments get the same generated name and now the integration tests fail.
To solve it I explicitly set different workspace name to the two sub environments in the `env0.workflow.yml` file.