### PR TITLE
Chore: Updating Squid-proxy to use a service

### DIFF
--- a/kubernetes/squid-proxy/README.md
+++ b/kubernetes/squid-proxy/README.md
@@ -7,8 +7,6 @@ All outgoing traffic from the agent must go through the proxy.
 ### Installing squid-proxy
 
 - Apply the `squid-proxy.yaml` file.
-- Get the proxy pod's IP - `kubectl get pod -n squid-proxy -l app=squid -o jsonpath={.items..podIP}`
-- TODO: Make the proxy use a k8s service, so we don't need to get the IP everytime we update the proxy config.
 
 ### Network Policy
 
@@ -26,7 +24,7 @@ All outgoing traffic from the agent must go through the proxy.
 - The agent should be installed with these values
 
 ```
-"httpProxy": "http://{proxy-ip}:3128"
-"httpsProxy": "http://{proxy-ip}:3128"
+"httpProxy": "http://squid-proxy-service.squid-proxy.svc.cluster.local:80"
+"httpsProxy": "http://squid-proxy-service.squid-proxy.svc.cluster.local:80"
 "noProxy": "{K8S ApiService IP/DNS}"
 ```

--- a/kubernetes/squid-proxy/network-policy.yaml
+++ b/kubernetes/squid-proxy/network-policy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default-deny-egress
-  namespace: env0-agent-pr11760
+  namespace: env0-agent-kushield # change this for the namespace you are working on - only requests to the proxy will be allowed
 spec:
   podSelector: {}
   policyTypes:

--- a/kubernetes/squid-proxy/network-policy.yaml
+++ b/kubernetes/squid-proxy/network-policy.yaml
@@ -4,12 +4,20 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: default-deny-egress
-  namespace: env0-agent-kushield # change this for the namespace you are working on
+  namespace: env0-agent-pr11760
 spec:
   podSelector: {}
   policyTypes:
     - Egress
   egress:
+    - to: # kube-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+
     - to: # proxy
         - podSelector:
             matchLabels:

--- a/kubernetes/squid-proxy/squid-proxy.yaml
+++ b/kubernetes/squid-proxy/squid-proxy.yaml
@@ -54,3 +54,19 @@ spec:
             - name: proxy-config
               mountPath: /etc/squid
               readOnly: true
+          ports:
+            - containerPort: 3128
+---
+# Service for exposing the proxy
+apiVersion: v1
+kind: Service
+metadata:
+  name: squid-proxy-service
+  namespace: squid-proxy
+spec:
+  selector:
+    app: squid
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3128


### PR DESCRIPTION
Makes it easier to use the proxy, as it isn't relying on IP's anymore but on DNS.