### PR TITLE
use aws eks command to auth instead of reading a kubeconfig env var

### DIFF
--- a/kubernetes/hello-world/env0.yml
+++ b/kubernetes/hello-world/env0.yml
@@ -4,8 +4,7 @@ deploy:
   steps:
     setupVariables:
       after: &login-k8s
-        - mkdir -p ~/.kube
-        - echo $KUBE_CONFIG > ~/.kube/config
+        - aws eks --region us-west-2 update-kubeconfig --name k8s-template-cluster-eksCluster-e8a88b9
         - kubectl config set-context aws --namespace $NAMESPACE;
         - echo "$(sed 's/!!!NAMESPACE!!!/'"$NAMESPACE"'/g' namespace.yaml)" > namespace.yaml;
         - cat namespace.yaml


### PR DESCRIPTION
Currently our hello-kubernetes example template requires a kubeconfig file to be injected, but in this case we use eks so we can simply use `aws update-kubeconfig` to handle it.

