### PR TITLE
Chore: Add azure secret integration test

### DIFF
--- a/misc/azure-vault-sensitive-var/README.md
+++ b/misc/azure-vault-sensitive-var/README.md
@@ -1,0 +1,4 @@
+This template validates that sensitive variables stored in azure vault are taken correctly during deployment.
+Relevant for self hosted agents only.
+
+It specifically validates that `$SHAG_FAKE_SECRET`'s value is `FAKE_NEWS`

--- a/misc/azure-vault-sensitive-var/README.md
+++ b/misc/azure-vault-sensitive-var/README.md
@@ -1,4 +1,4 @@
 This template validates that sensitive variables stored in azure vault are taken correctly during deployment.
 Relevant for self hosted agents only.
 
-It specifically validates that `$SHAG_FAKE_SECRET`'s value is `FAKE_NEWS`
+It specifically validates that `$AZURE_SHAG_FAKE_SECRET`'s value is `FAKE_NEWS`

--- a/misc/azure-vault-sensitive-var/env0.yml
+++ b/misc/azure-vault-sensitive-var/env0.yml
@@ -1,0 +1,8 @@
+version: 1
+
+deploy:
+  steps:
+    setupVariables:
+      after:
+        - chmod +x validate.sh
+        - ./validate.sh

--- a/misc/azure-vault-sensitive-var/main.tf
+++ b/misc/azure-vault-sensitive-var/main.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "null1" {
+}

--- a/misc/azure-vault-sensitive-var/main.tf
+++ b/misc/azure-vault-sensitive-var/main.tf
@@ -1,2 +1,2 @@
-resource "null_resource" "null1" {
+resource "null_resource" "null" {
 }

--- a/misc/azure-vault-sensitive-var/validate.sh
+++ b/misc/azure-vault-sensitive-var/validate.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
-if [[ "$SHAG_FAKE_SECRET" == "FAKE_NEWS" ]];
+if [[ "$AZURE_SHAG_FAKE_SECRET" == "FAKE_NEWS" ]];
 then
   echo "Loaded secret from azure vault successfully"
   exit 0
 else
-  echo "Validation failed! Value of azure vault secret is $SHAG_FAKE_SECRET"
+  echo "Validation failed! Value of azure vault secret is $AZURE_SHAG_FAKE_SECRET"
   exit 1
 fi

--- a/misc/azure-vault-sensitive-var/validate.sh
+++ b/misc/azure-vault-sensitive-var/validate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+if [[ "$SHAG_FAKE_SECRET" == "FAKE_NEWS" ]];
+then
+  echo "Loaded secret from azure vault successfully"
+  exit 0
+else
+  echo "Validation failed! Value of azure vault secret is $SHAG_FAKE_SECRET"
+  exit 1
+fi


### PR DESCRIPTION
To check that we can read sensitive values from azure vault I need to add this template.
It's basically a copy of [this](https://github.com/env0/templates/tree/master/misc/ssm-sensitive-var) aws test for ssm