### PR TITLE
Feat: Use workspace name prefix in basic dependencies  workflow example

### DIFF
--- a/misc/workflow-environment-basic-dependencies/README.md
+++ b/misc/workflow-environment-basic-dependencies/README.md
@@ -28,4 +28,6 @@ To successfully run - you can either create that template in your organization o
 ### Running the template
 
 Now that the template is defined, you can simply run it in any env0 project using the "Create New Environment" button. 
-Make sure to pick the template defined in the last step
+Make sure to pick the template defined in the last step.
+
+**When creating the environment make sure to define an environment variable named WORKSPACE_PREFIX with your desired workspace prefix as its value** 

--- a/misc/workflow-environment-basic-dependencies/env0.workflow.yml
+++ b/misc/workflow-environment-basic-dependencies/env0.workflow.yml
@@ -2,28 +2,28 @@ environments:
   rootService1:
     name: rootService1
     templateName: 'null'
-    workspace: r1-${ENV0_WORKSPACE_NAME}
+    workspace: 'r1-${ENV0_WORKSPACE_NAME}'
   rootService2:
     name: rootService2
     templateName: 'null'
-    workspace: r2-${ENV0_WORKSPACE_NAME}
+    workspace: 'r2-${ENV0_WORKSPACE_NAME}'
   middleService1:
     name: middleService1
     templateName: 'null'
-    workspace: m1-${ENV0_WORKSPACE_NAME}
+    workspace: 'm1-${ENV0_WORKSPACE_NAME}'
     needs:
       - rootService1
       - rootService2
   middleService2:
     name: middleService2
     templateName: 'null'
-    workspace: m2-${ENV0_WORKSPACE_NAME}
+    workspace: 'm2-${ENV0_WORKSPACE_NAME}'
     needs:
       - rootService1
       - rootService2
   finalService:
     name: finalService
     templateName: 'null'
-    workspace: f1-${ENV0_WORKSPACE_NAME}
+    workspace: 'f1-${ENV0_WORKSPACE_NAME}'
     needs:
       - middleService1

--- a/misc/workflow-environment-basic-dependencies/env0.workflow.yml
+++ b/misc/workflow-environment-basic-dependencies/env0.workflow.yml
@@ -2,28 +2,28 @@ environments:
   rootService1:
     name: rootService1
     templateName: 'null'
-    workspace: r1_${ENV0_WORKSPACE_NAME}
+    workspace: ${WORKSPACE_PREFIX}_r1
   rootService2:
     name: rootService2
     templateName: 'null'
-    workspace: r2_${ENV0_WORKSPACE_NAME}
+    workspace: ${WORKSPACE_PREFIX}_r2
   middleService1:
     name: middleService1
     templateName: 'null'
-    workspace: m1_${ENV0_WORKSPACE_NAME}
+    workspace: ${WORKSPACE_PREFIX}_m1
     needs:
       - rootService1
       - rootService2
   middleService2:
     name: middleService2
     templateName: 'null'
-    workspace: m2_${ENV0_WORKSPACE_NAME}
+    workspace: ${WORKSPACE_PREFIX}_m2
     needs:
       - rootService1
       - rootService2
   finalService:
     name: finalService
     templateName: 'null'
-    workspace: f1_${ENV0_WORKSPACE_NAME}
+    workspace: ${WORKSPACE_PREFIX}_f1
     needs:
       - middleService1

--- a/misc/workflow-environment-basic-dependencies/env0.workflow.yml
+++ b/misc/workflow-environment-basic-dependencies/env0.workflow.yml
@@ -2,28 +2,28 @@ environments:
   rootService1:
     name: rootService1
     templateName: 'null'
-    workspace: 'r1-${ENV0_WORKSPACE_NAME}'
+    workspace: r1_${ENV0_WORKSPACE_NAME}
   rootService2:
     name: rootService2
     templateName: 'null'
-    workspace: 'r2-${ENV0_WORKSPACE_NAME}'
+    workspace: r2_${ENV0_WORKSPACE_NAME}
   middleService1:
     name: middleService1
     templateName: 'null'
-    workspace: 'm1-${ENV0_WORKSPACE_NAME}'
+    workspace: m1_${ENV0_WORKSPACE_NAME}
     needs:
       - rootService1
       - rootService2
   middleService2:
     name: middleService2
     templateName: 'null'
-    workspace: 'm2-${ENV0_WORKSPACE_NAME}'
+    workspace: m2_${ENV0_WORKSPACE_NAME}
     needs:
       - rootService1
       - rootService2
   finalService:
     name: finalService
     templateName: 'null'
-    workspace: 'f1-${ENV0_WORKSPACE_NAME}'
+    workspace: f1_${ENV0_WORKSPACE_NAME}
     needs:
       - middleService1

--- a/misc/workflow-environment-basic-dependencies/env0.workflow.yml
+++ b/misc/workflow-environment-basic-dependencies/env0.workflow.yml
@@ -2,28 +2,28 @@ environments:
   rootService1:
     name: rootService1
     templateName: 'null'
-    workspace: r1${ENV0_WORKSPACE_NAME}
+    workspace: r1_${ENV0_WORKSPACE_NAME}
   rootService2:
     name: rootService2
     templateName: 'null'
-    workspace: r2${ENV0_WORKSPACE_NAME}
+    workspace: r2_${ENV0_WORKSPACE_NAME}
   middleService1:
     name: middleService1
     templateName: 'null'
-    workspace: m1${ENV0_WORKSPACE_NAME}
+    workspace: m1_${ENV0_WORKSPACE_NAME}
     needs:
       - rootService1
       - rootService2
   middleService2:
     name: middleService2
     templateName: 'null'
-    workspace: m2${ENV0_WORKSPACE_NAME}
+    workspace: m2_${ENV0_WORKSPACE_NAME}
     needs:
       - rootService1
       - rootService2
   finalService:
     name: finalService
     templateName: 'null'
-    workspace: f1${ENV0_WORKSPACE_NAME}
+    workspace: f1_${ENV0_WORKSPACE_NAME}
     needs:
       - middleService1

--- a/misc/workflow-environment-basic-dependencies/env0.workflow.yml
+++ b/misc/workflow-environment-basic-dependencies/env0.workflow.yml
@@ -2,28 +2,28 @@ environments:
   rootService1:
     name: rootService1
     templateName: 'null'
-    workspace: 'null-root-1'
+    workspace: r1-${ENV0_WORKSPACE_NAME}
   rootService2:
     name: rootService2
     templateName: 'null'
-    workspace: 'null-root-2'
+    workspace: r2-${ENV0_WORKSPACE_NAME}
   middleService1:
     name: middleService1
     templateName: 'null'
-    workspace: 'null-middle-1'
+    workspace: m1-${ENV0_WORKSPACE_NAME}
     needs:
       - rootService1
       - rootService2
   middleService2:
     name: middleService2
     templateName: 'null'
-    workspace: 'null-middle-2'
+    workspace: m2-${ENV0_WORKSPACE_NAME}
     needs:
       - rootService1
       - rootService2
   finalService:
     name: finalService
     templateName: 'null'
-    workspace: 'null-final-1'
+    workspace: f1-${ENV0_WORKSPACE_NAME}
     needs:
       - middleService1

--- a/misc/workflow-environment-basic-dependencies/env0.workflow.yml
+++ b/misc/workflow-environment-basic-dependencies/env0.workflow.yml
@@ -2,28 +2,28 @@ environments:
   rootService1:
     name: rootService1
     templateName: 'null'
-    workspace: r1_${ENV0_WORKSPACE_NAME}
+    workspace: r1${ENV0_WORKSPACE_NAME}
   rootService2:
     name: rootService2
     templateName: 'null'
-    workspace: r2_${ENV0_WORKSPACE_NAME}
+    workspace: r2${ENV0_WORKSPACE_NAME}
   middleService1:
     name: middleService1
     templateName: 'null'
-    workspace: m1_${ENV0_WORKSPACE_NAME}
+    workspace: m1${ENV0_WORKSPACE_NAME}
     needs:
       - rootService1
       - rootService2
   middleService2:
     name: middleService2
     templateName: 'null'
-    workspace: m2_${ENV0_WORKSPACE_NAME}
+    workspace: m2${ENV0_WORKSPACE_NAME}
     needs:
       - rootService1
       - rootService2
   finalService:
     name: finalService
     templateName: 'null'
-    workspace: f1_${ENV0_WORKSPACE_NAME}
+    workspace: f1${ENV0_WORKSPACE_NAME}
     needs:
       - middleService1


### PR DESCRIPTION
Accept an ENV var that defined a prefix for the sub environments workspace names