### PR TITLE
remove workspace name from workflow file

### DIFF
--- a/misc/workflow-environment-basic-dependencies/env0.workflow.yml
+++ b/misc/workflow-environment-basic-dependencies/env0.workflow.yml
@@ -2,28 +2,23 @@ environments:
   rootService1:
     name: rootService1
     templateName: 'null'
-    workspace: ${WORKSPACE_PREFIX}_r1
   rootService2:
     name: rootService2
     templateName: 'null'
-    workspace: ${WORKSPACE_PREFIX}_r2
   middleService1:
     name: middleService1
     templateName: 'null'
-    workspace: ${WORKSPACE_PREFIX}_m1
     needs:
       - rootService1
       - rootService2
   middleService2:
     name: middleService2
     templateName: 'null'
-    workspace: ${WORKSPACE_PREFIX}_m2
     needs:
       - rootService1
       - rootService2
   finalService:
     name: finalService
     templateName: 'null'
-    workspace: ${WORKSPACE_PREFIX}_f1
     needs:
       - middleService1


### PR DESCRIPTION
This isn't needed since workflow integration tests add workspace themselves, so having it on the WF file is wrong and caused errors since we don't have the WORKSPACE_NAME anymore

![image](https://github.com/env0/templates/assets/9664064/0181f3f3-c037-4def-b96c-2859d2c52563)
