### PR TITLE
update version to support chdir

### DIFF
--- a/plugins/tflint/env0.yml
+++ b/plugins/tflint/env0.yml
@@ -6,6 +6,6 @@ deploy:
       - name: tflint
         use: https://github.com/env0/env0-tflint-plugin
         inputs:
-          version: v0.43.0
+          version: v0.50.3
           directory: .
 

--- a/plugins/tflint/env0.yml
+++ b/plugins/tflint/env0.yml
@@ -6,6 +6,6 @@ deploy:
       - name: tflint
         use: https://github.com/env0/env0-tflint-plugin
         inputs:
-          version: v0.47.0
+          version: v0.50.3
           directory: .
 

--- a/plugins/tflint/env0.yml
+++ b/plugins/tflint/env0.yml
@@ -6,6 +6,6 @@ deploy:
       - name: tflint
         use: https://github.com/env0/env0-tflint-plugin
         inputs:
-          version: v0.50.0
+          version: v0.47.0
           directory: .
 

--- a/plugins/tflint/env0.yml
+++ b/plugins/tflint/env0.yml
@@ -6,6 +6,6 @@ deploy:
       - name: tflint
         use: https://github.com/env0/env0-tflint-plugin
         inputs:
-          version: v0.50.3
+          version: v0.50.0
           directory: .
 

--- a/plugins/tflint/main.tf
+++ b/plugins/tflint/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    null        = "~> 3.2.1"
+    null = "latest"
   }
 }
 

--- a/plugins/tflint/main.tf
+++ b/plugins/tflint/main.tf
@@ -2,10 +2,7 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    null = {
-      source  = "hashicorp/null"
-      version = "latest"
-    }
+    null        = "~> 3.2.2"
   }
 }
 

--- a/plugins/tflint/main.tf
+++ b/plugins/tflint/main.tf
@@ -2,7 +2,10 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    null = "latest"
+    null = {
+      source  = "hashicorp/null"
+      version = "latest"
+    }
   }
 }
 

--- a/plugins/tflint/main.tf
+++ b/plugins/tflint/main.tf
@@ -2,7 +2,10 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    null        = "~> 3.2.2"
+    null = {
+      source = "hashicorp/null"
+      version = "3.2.2"
+    }
   }
 }
 


### PR DESCRIPTION
We need a upgraded version since as of the [plugin upgrade](https://github.com/env0/env0-tflint-plugin/pull/2), we don't support version below 0.44.0