### PR TITLE
Add Helm dependencies

### DIFF
--- a/helm/dummy/Chart.yaml
+++ b/helm/dummy/Chart.yaml
@@ -22,3 +22,9 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.16.0"
+
+# a dummy dependency showing how dependencies are also built from source
+dependencies:
+  - name: hello-world
+    version: "0.1.0"
+    repository: "https://helm.github.io/examples"


### PR DESCRIPTION
Adding dummy dependencies to show how env0's Helm can now handle having chart dependencies when targeting a source of chart