### PR TITLE
Fix: Add missing pip flag

### DIFF
--- a/misc/ensure-permissions-on-tools-and-folders-for-user-node/ensure-permissions.sh
+++ b/misc/ensure-permissions-on-tools-and-folders-for-user-node/ensure-permissions.sh
@@ -50,7 +50,7 @@ helm repo update
 helm show chart env0/env0-agent
 
 # Check packages install
-pip install --user ansible
+pip install --break-system-packages --user ansible
 ansible --version
 
 sudo apk add --no-cache rsync


### PR DESCRIPTION
In the new pip version we get the following error:
```
The system-wide python installation should be maintained using the system
    package manager (apk) only.
```
We solve that by adding the `--break-system-packages` flag