### PR TITLE
Call TG built-in functions

### DIFF
--- a/terragrunt/misc/module-resource/simple/terragrunt.hcl
+++ b/terragrunt/misc/module-resource/simple/terragrunt.hcl
@@ -1,3 +1,28 @@
 include {
   path = find_in_parent_folders()
 }
+
+generate "output" {
+  path = "output.tf"
+  if_exists = "overwrite_terragrunt"
+  contents = <<EOF
+
+output "find_IN_PARENT_folder" {
+  value = "${find_in_parent_folders()}"
+}
+output "get_TG_dir" {
+  value = "${get_terragrunt_dir()}"
+}
+output "get_ORIG_WORKDIR" {
+  value = "${get_original_terragrunt_dir()}"
+}
+output "FROM" {
+  value = "${get_path_from_repo_root()}"
+}
+output "TO" {
+  value = "${get_path_to_repo_root()}"
+}
+
+
+EOF
+}


### PR DESCRIPTION
We recently had issues with some TG built-in functions during output step. This PR adds these function calls to the output step to run during integration tests