### PR TITLE
chore: Update Azure provider

### DIFF
--- a/azure/resource-group/main.tf
+++ b/azure/resource-group/main.tf
@@ -1,5 +1,14 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.0.0"
+    }
+  }
+}
+
 provider "azurerm" {
-  version = "~> 1.15"
+  features {}
 }
 
 resource "random_string" "random" {


### PR DESCRIPTION
Looks like Azure deprecated the method we used to auth. upgrade fix it 