### PR TITLE
Add azure/validate-client-config and aws/validate-caller-identity templates for OIDC integration tests

### DIFF
--- a/aws/validate-caller-identity/README.md
+++ b/aws/validate-caller-identity/README.md
@@ -1,0 +1,7 @@
+### Validate Caller Identity
+
+Terraform-native validation that env0 authenticated as the expected AWS identity.
+
+Reads `data.aws_caller_identity` (a real authenticated `sts:GetCallerIdentity` call) and fails the apply via a `precondition` unless the assumed ARN contains the substring in the `expected_arn` variable.
+
+Unlike `misc/validate-assume-role` — which validates in a pre-terraform custom-flow step (`setupVariables.after`) — this asserts during terraform apply. That matters for credential types whose AWS credentials are only injected at the `template:init` step (after the custom-flow hook), such as AWS OIDC.

--- a/aws/validate-caller-identity/main.tf
+++ b/aws/validate-caller-identity/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {}
+
+variable "expected_arn" {
+  description = "Substring expected in the ARN terraform authenticates as (e.g. the assumed-role ARN)"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "terraform_data" "validate_authenticated_identity" {
+  input = data.aws_caller_identity.current.arn
+
+  lifecycle {
+    precondition {
+      condition     = strcontains(data.aws_caller_identity.current.arn, var.expected_arn)
+      error_message = "Authenticated as '${data.aws_caller_identity.current.arn}', expected the ARN to contain '${var.expected_arn}'."
+    }
+  }
+}
+
+output "authenticated_arn" {
+  value = data.aws_caller_identity.current.arn
+}

--- a/azure/validate-client-config/README.md
+++ b/azure/validate-client-config/README.md
@@ -1,8 +1,13 @@
 # Validate Azure Client Config
 
-Validates that terraform authenticated against Azure as the expected identity — the Azure analog of `misc/validate-assume-role`.
+Validates that terraform actually authenticated against Azure as the expected identity — the Azure analog of `misc/validate-assume-role`.
 
-Reads the authenticated principal via `data "azurerm_client_config"` and fails the plan with a precondition if its `client_id` doesn't match the `expected_client_id` variable. No Azure resources are created, so Reader-level permissions are enough.
+Two layers of validation:
+
+1. `data "azurerm_subscription"` performs a real, authenticated ARM read. This forces the provider to acquire an AAD access token (for OIDC auth: exchanging the federated token as the configured client id) — if authentication is broken the plan fails here.
+2. A plan-time precondition asserts the authenticated `client_id` matches the `expected_client_id` variable. AAD only issues a token for a client whose federated credential trusts the presented token, so a successful ARM read plus this check pins the deployment to the expected service principal.
+
+No Azure resources are created; Reader on the subscription is enough.
 
 Used by env0's template-integration tests to verify deployments authenticate via an `AZURE_OIDC` deployment credential.
 

--- a/azure/validate-client-config/README.md
+++ b/azure/validate-client-config/README.md
@@ -1,0 +1,11 @@
+# Validate Azure Client Config
+
+Validates that terraform authenticated against Azure as the expected identity — the Azure analog of `misc/validate-assume-role`.
+
+Reads the authenticated principal via `data "azurerm_client_config"` and fails the plan with a precondition if its `client_id` doesn't match the `expected_client_id` variable. No Azure resources are created, so Reader-level permissions are enough.
+
+Used by env0's template-integration tests to verify deployments authenticate via an `AZURE_OIDC` deployment credential.
+
+## Variables
+
+- `expected_client_id` — the client id (application id) terraform is expected to authenticate as.

--- a/azure/validate-client-config/main.tf
+++ b/azure/validate-client-config/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+variable "expected_client_id" {
+  description = "The client id terraform is expected to authenticate as"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "terraform_data" "validate_client_id" {
+  lifecycle {
+    precondition {
+      condition     = data.azurerm_client_config.current.client_id == var.expected_client_id
+      error_message = "Authenticated as client_id '${data.azurerm_client_config.current.client_id}', expected '${var.expected_client_id}'."
+    }
+  }
+}
+
+output "authenticated_client_id" {
+  value = data.azurerm_client_config.current.client_id
+}

--- a/azure/validate-client-config/main.tf
+++ b/azure/validate-client-config/main.tf
@@ -20,15 +20,28 @@ variable "expected_client_id" {
 
 data "azurerm_client_config" "current" {}
 
-resource "terraform_data" "validate_client_id" {
+data "azurerm_subscription" "current" {}
+
+resource "terraform_data" "validate_authenticated_identity" {
+  input = data.azurerm_subscription.current.subscription_id
+
   lifecycle {
     precondition {
       condition     = data.azurerm_client_config.current.client_id == var.expected_client_id
       error_message = "Authenticated as client_id '${data.azurerm_client_config.current.client_id}', expected '${var.expected_client_id}'."
+    }
+
+    precondition {
+      condition     = data.azurerm_subscription.current.tenant_id == data.azurerm_client_config.current.tenant_id
+      error_message = "Subscription tenant '${data.azurerm_subscription.current.tenant_id}' does not match the authenticated tenant '${data.azurerm_client_config.current.tenant_id}'."
     }
   }
 }
 
 output "authenticated_client_id" {
   value = data.azurerm_client_config.current.client_id
+}
+
+output "subscription_display_name" {
+  value = data.azurerm_subscription.current.display_name
 }


### PR DESCRIPTION
Adds two terraform-native validation templates that assert env0 actually authenticated as the expected cloud identity — analogous to `misc/validate-assume-role`, but checking *inside* terraform rather than in a pre-terraform custom-flow step. Both are used by new template-integration tests in env0/env0 ([ENG-1772](https://linear.app/env-zero/issue/ENG-1772/test-template-integration-e2e-aws-azure-oidc-deployment-on-legacy-v1)), baseline regression guards for deployments authenticating via `AZURE_OIDC` / `AWS_OIDC` deployment credentials.

### `azure/validate-client-config`

Validates terraform authenticated against Azure as the expected identity. Two layers: `data azurerm_subscription` performs a real authenticated ARM read (forcing the AAD token acquisition — for OIDC auth, the federated-token exchange — so broken trust fails the plan), and a plan-time precondition asserts the authenticated `client_id` matches `expected_client_id`. `data azurerm_client_config` alone wouldn't validate anything — it's offline and just echoes the provider configuration. No resources created; Reader on the subscription suffices (`resource_provider_registrations = "none"`). The existing `azure/resource-group` template couldn't be reused because it pins azurerm `=3.0.0`, which predates OIDC auth support (added in 3.7.0).

### `aws/validate-caller-identity`

The AWS analog. `misc/validate-assume-role` validates in a `setupVariables.after` custom-flow step, which runs **before** env0 injects OIDC-assumed AWS credentials (that happens at `template:init`) — so an OIDC deployment has no credentials there and the script fails with `Unable to locate credentials`. This template instead reads `data.aws_caller_identity` (a real authenticated `sts:GetCallerIdentity`) during apply and fails via a `precondition` unless the assumed ARN contains `expected_arn`. Works for any credential type whose AWS creds are only available at the terraform step.