### PR TITLE
fix: Change tracking in aws/hello-world

### DIFF
--- a/aws/hello-world/s3.tf
+++ b/aws/hello-world/s3.tf
@@ -79,4 +79,5 @@ resource "aws_s3_object" "object" {
   key          = "index.html"
   source       = "index.html"
   content_type = "text/html"
+  etag         = filemd5("index.html")
 }


### PR DESCRIPTION
Without the checksum based etag any changes to `index.html` after initial object creation are not tracked / don't generate any Tofu diff.