### PR TITLE
[APO-88] Fix: hello-world change tracking without plan-time generated file

### DIFF
--- a/aws/hello-world/env0.yml
+++ b/aws/hello-world/env0.yml
@@ -1,8 +1,0 @@
-version: 1
-
-deploy:
-  steps:
-    terraformInit:
-      before:
-        - echo Replacing !!!USER!!! with $USER in index.html
-        - sed 's/!!!USER!!!/'"$USER"'/g' index.template.html > index.html

--- a/aws/hello-world/env0.yml
+++ b/aws/hello-world/env0.yml
@@ -1,0 +1,7 @@
+version: 1
+
+deploy:
+  steps:
+    terraformInit:
+      before:
+        - echo "Running env0 custom deploy flow for the hello-world template"

--- a/aws/hello-world/main.tf
+++ b/aws/hello-world/main.tf
@@ -6,3 +6,12 @@ provider "aws" {
 terraform {
   required_version = ">= 0.13"
 }
+
+variable "user" {
+  type    = string
+  default = "env0"
+}
+
+locals {
+  index_html = replace(file("${path.module}/index.template.html"), "!!!USER!!!", var.user)
+}

--- a/aws/hello-world/s3.tf
+++ b/aws/hello-world/s3.tf
@@ -77,7 +77,7 @@ resource "aws_s3_bucket_policy" "website_bucket_policy" {
 resource "aws_s3_object" "object" {
   bucket       = aws_s3_bucket.website_bucket.bucket
   key          = "index.html"
-  source       = "index.html"
+  content      = local.index_html
   content_type = "text/html"
-  etag         = filemd5("index.html")
+  etag         = md5(local.index_html)
 }


### PR DESCRIPTION
### Issue

PR #329 added `etag = filemd5("index.html")` to `aws/hello-world/s3.tf` to track changes to the page. But `index.html` is **not committed** - it is generated at deploy time by `env0.yml`:

```
sed 's/!!!USER!!!/'"$USER"'/g' index.template.html > index.html
```

`filemd5` is evaluated at **plan** time, before that generated file reliably exists, so template integration tests fail:

```
Call to function "filemd5" failed: open index.html: no such file or directory.
```

The old `source = "index.html"` only read the file at **apply** time, so the plan-only path never hit a missing file. This is not a Terraform/provider version issue.

Failing run: https://github.com/env0/env0/actions/runs/27699749492/job/81932792956
Linear: APO-88

### Solution

Stop hashing a runtime-generated file. Render the page content inside Terraform from the committed `index.template.html` and hash the content:

- `main.tf`: add `variable "user"` (default `env0`) and `local.index_html = replace(file("${path.module}/index.template.html"), "!!!USER!!!", var.user)`
- `s3.tf`: `content = local.index_html` + `etag = md5(local.index_html)` (replaces `source` + `filemd5`)
- `env0.yml`: keep the custom-flow demo but make it an echo-only step (no longer generates `index.html`)

`md5(content)` equals S3's etag for single-part uploads, so change tracking works with no false drift, and the committed template always exists at plan time. Personalization moves from the OS `$USER` to the optional `user` Terraform variable.

### How I _manually_ verified it works

- [x] `terraform fmt -check` clean; `terraform init -backend=false` + `terraform validate` -> Success (only a pre-existing provider-version-block warning, unrelated to this change)
- [x] run workspace and verify it succeded
<img width="514" height="171" alt="image" src="https://github.com/user-attachments/assets/4880cfe1-f3e3-4f79-9dca-703c9d6e5581" />
